### PR TITLE
add load and save buttons using shinyFiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
   shinyAce (>= 0.4.1),
   shinybusy (>= 0.2.0),
   shinycssloaders (>= 0.3),
+  shinyFiles (>= 0.9.3),
   targets (>= 0.2.0),
   tarchetypes (>= 0.1.0),
   tidyverse (>= 1.3.0),

--- a/R/server.R
+++ b/R/server.R
@@ -97,15 +97,15 @@ server <- function(input, output, session) {
     input$loadFile, {
       shinyFiles::shinyFileChoose(
         input,
-        'loadFile',
-        roots = c(root = '.'),
-        filetypes = c('', 'R', 'md')
+        "loadFile",
+        roots = c(root = "."),
+        filetypes = c("", "R", "r")
       )
       inFile <- shinyFiles::parseFilePaths(
         roots = c(root = "."),
         input$loadFile
       )
-      if(length(inFile$datapath) > 0){
+      if (length(inFile$datapath) > 0) {
         lines <- readLines(inFile$datapath)
         shinyAce::updateAceEditor(
           session,
@@ -119,7 +119,7 @@ server <- function(input, output, session) {
     }
   )
   observeEvent(
-    input$saveFile,{
+    input$saveFile, {
       shinyFiles::shinyFileSave(
         input,
         "saveFile",
@@ -128,7 +128,8 @@ server <- function(input, output, session) {
       if (length(input$saveFile) > 1) {
         fileinfo <- shinyFiles::parseSavePath(
           roots = c(root = "."),
-          input$saveFile)
+          input$saveFile
+        )
         writeLines(input$script, as.character(fileinfo$datapath))
       }
     }

--- a/R/server.R
+++ b/R/server.R
@@ -40,10 +40,6 @@ server <- function(input, output, session) {
   )
   output$manifest <- DT::renderDataTable(values$manifest, rownames = FALSE)
   output$graph <- visNetwork::renderVisNetwork(values$graph)
-  output$download <- shiny::downloadHandler(
-    filename = function() "_targets.R",
-    content = function(con) writeLines(input$script, con)
-  )
   output$clip <- shiny::renderUI({
     output$clip <- shiny::renderUI({
       rclipboard::rclipButton(

--- a/R/server.R
+++ b/R/server.R
@@ -93,6 +93,47 @@ server <- function(input, output, session) {
       )
     }
   })
+  shiny::observeEvent(
+    input$loadFile, {
+      shinyFiles::shinyFileChoose(
+        input,
+        'loadFile',
+        roots = c(root = '.'),
+        filetypes = c('', 'R', 'md')
+      )
+      inFile <- shinyFiles::parseFilePaths(
+        roots = c(root = "."),
+        input$loadFile
+      )
+      if(length(inFile$datapath) > 0){
+        lines <- readLines(inFile$datapath)
+        shinyAce::updateAceEditor(
+          session,
+          "script",
+          paste(
+            lines,
+            collapse = "\n"
+          )
+        )
+      }
+    }
+  )
+  observeEvent(
+    input$saveFile,{
+      shinyFiles::shinyFileSave(
+        input,
+        "saveFile",
+        roots = c(root = ".")
+      )
+      if (length(input$saveFile) > 1) {
+        fileinfo <- shinyFiles::parseSavePath(
+          roots = c(root = "."),
+          input$saveFile)
+        writeLines(input$script, as.character(fileinfo$datapath))
+      }
+    }
+  )
+
 }
 
 update_values <- function(values, input) {

--- a/R/server.R
+++ b/R/server.R
@@ -44,7 +44,7 @@ server <- function(input, output, session) {
     output$clip <- shiny::renderUI({
       rclipboard::rclipButton(
         inputId = "clipbtn",
-        label = "Copy",
+        label = "Copy _targets.R",
         clipText = input$script,
         icon = shiny::icon("clipboard")
       )

--- a/R/ui.R
+++ b/R/ui.R
@@ -49,7 +49,7 @@ ui <- function() {
               shinyFiles::shinyFilesButton(
                 "loadFile",
                 "Load _targets.R",
-                title = 'Please select a file',
+                title = "Please select a file",
                 multiple = FALSE,
                 icon = shiny::icon("upload")
               )
@@ -59,7 +59,7 @@ ui <- function() {
               shinyFiles::shinySaveButton(
                 "saveFile",
                 "Save _targets.R",
-                title = 'Please select a folder',
+                title = "Please select a folder",
                 icon = shiny::icon("save")
               )
             )

--- a/R/ui.R
+++ b/R/ui.R
@@ -20,7 +20,7 @@ ui <- function() {
               style = "display:inline-block",
               shiny::actionButton(
                 "update",
-                "Update",
+                "Update displays",
                 icon = shiny::icon("redo-alt")
               )
             ),

--- a/R/ui.R
+++ b/R/ui.R
@@ -43,6 +43,25 @@ ui <- function() {
                 title = "Add new target to your list",
                 placement = "bottom"
               )
+            ),
+            shiny::div(
+              style = "display:inline-block",
+              shinyFiles::shinyFilesButton(
+                "loadFile",
+                "Load _targets.R",
+                title = 'Please select a file',
+                multiple = FALSE,
+                icon = shiny::icon("upload")
+              )
+            ),
+            shiny::div(
+              style = "display:inline-block",
+              shinyFiles::shinySaveButton(
+                "saveFile",
+                "Save _targets.R",
+                title = 'Please select a folder',
+                icon = shiny::icon("save")
+              )
             )
           ),
           bs4Dash::bs4Card(

--- a/R/ui.R
+++ b/R/ui.R
@@ -24,10 +24,6 @@ ui <- function() {
                 icon = shiny::icon("redo-alt")
               )
             ),
-            shiny::div(
-              style = "display:inline-block",
-              shiny::downloadButton("download", "Download")
-            ),
             shiny::div(style = "display:inline-block", shiny::uiOutput("clip")),
             shiny::div(style = "display:inline-block", shiny::actionButton(
               "reset",

--- a/R/ui.R
+++ b/R/ui.R
@@ -59,6 +59,7 @@ ui <- function() {
               shinyFiles::shinySaveButton(
                 "saveFile",
                 "Save _targets.R",
+                filename = "_targets.R",
                 title = "Please select a folder",
                 icon = shiny::icon("save")
               )


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://github.com/wlandau/targetsketch/blob/main/CODE_OF_CONDUCT.md).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/wlandau/targetsketch/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/wlandau/targetsketch/issues) to discuss my idea with the maintainer.

# Summary

Please explain the purpose and scope of your contribution.

Addresses most of #25. Added load and save _targets.R buttons that use [{shinyFiles}](https://github.com/thomasp85/shinyFiles). 

For another PR, I'd like to add an argument into targetsketch::targetsketch() where we can declare the reference _targets.R path to load. Note that you may want to disable these shinyFiles functionalities if publishing onto shinyapps.io, @wlandau.

# Related GitHub issues and pull requests

* Ref: #25 
# Checklist

* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
