### PR TITLE
add maximizable card for code, manifest and graph cards in shinyapp

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -69,6 +69,7 @@ ui <- function(script) {
             )
           ),
           bs4Dash::bs4Card(
+            maximizable = TRUE,
             title = "_targets.R",
             width = 12,
             status = "primary",
@@ -90,6 +91,7 @@ ui <- function(script) {
         bs4Dash::bs4Sortable(
           width = 12,
           bs4Dash::bs4Card(
+            maximizable = TRUE,
             title = "Graph",
             width = 12,
             status = "success",
@@ -101,6 +103,7 @@ ui <- function(script) {
           ),
           bs4Dash::bs4Card(
             title = "Manifest",
+            maximizable = TRUE,
             width = 12,
             status = "success",
             closable = FALSE,


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://github.com/wlandau/targetsketch/blob/main/CODE_OF_CONDUCT.md).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/wlandau/targetsketch/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/wlandau/targetsketch/issues) to discuss my idea with the maintainer.

# Summary

bs4Dash Card function now has the option of maximizing them. 
So for UX I added the ability to maximize the graph, manifesto and source cards to allow focusing on those

# Related GitHub issues and pull requests

* Ref: #

# Checklist

* [ ] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
